### PR TITLE
Accomodate for other than $GP... strings

### DIFF
--- a/src/trunk/ntripclient/ntripclient.c
+++ b/src/trunk/ntripclient/ntripclient.c
@@ -1660,6 +1660,7 @@ int main(int argc, char **argv)
                         {
                           if(nmeabuffer[nmeabufpos] != buf[j])
                           {
+                            if(nmeabufpos == 2) nmeabuffer[nmeabufpos++] = buf[j++];
                             if(nmeabufpos) nmeabufpos = 0;
                             else ++j;
                           }

--- a/src/trunk/ntripclient/ntripclient.c
+++ b/src/trunk/ntripclient/ntripclient.c
@@ -1661,7 +1661,7 @@ int main(int argc, char **argv)
                           if(nmeabuffer[nmeabufpos] != buf[j])
                           {
                             if(nmeabufpos == 2) nmeabuffer[nmeabufpos++] = buf[j++];
-                            if(nmeabufpos) nmeabufpos = 0;
+                            else if(nmeabufpos) nmeabufpos = 0;
                             else ++j;
                           }
                           else


### PR DESCRIPTION
Add exeption for the P in for example $GPGGA. This could also be $GNGGA, with the proposed change this is possible.